### PR TITLE
fix: remove unnecessary 'limit' prop from Props interface

### DIFF
--- a/src/InfiniteScroll.tsx
+++ b/src/InfiniteScroll.tsx
@@ -23,7 +23,6 @@ interface Props<T> {
     loadingComponent?: React.ReactNode;
     errorComponent?: React.ReactNode;
     reverse?: boolean;
-    limit: number;
     style?: React.CSSProperties;
     className?: string;
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the `Props` interface in `src/InfiniteScroll.tsx` by removing the `limit` property. This change simplifies the interface and indicates that the `limit` property is no longer required or used.