### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ function PostList() {
     };
 
     return (
-        <InfiniteScroll<Post>
-            limit={10}
+        <InfiniteScroll
             loadItems={fetchPosts}
             renderItem={(item) => <div key={item.id}>{item.title}</div>}
         />
@@ -79,7 +78,6 @@ function PostList() {
 
     return (
         <InfiniteScroll
-            limit={10}
             loadItems={fetchPosts}
             renderItem={(item) => <div key={item.id}>{item.title}</div>}
         />
@@ -121,9 +119,7 @@ const ref = useRef<InfiniteScrollHandle<T>>(null);
 ## 🔄 Reverse Mode Example (Chat UI)
 
 ```tsx
-<InfiniteScroll<Message>
-    ref={scrollRef}
-    limit={20}
+<InfiniteScroll
     reverse
     loadItems={loadMessages}
     renderItem={(msg) => (


### PR DESCRIPTION
This pull request simplifies the usage of the `InfiniteScroll` component in the `README.md` file by removing the generic type parameter and the `limit` prop from the examples.

Simplification of `InfiniteScroll` usage:

* Removed the generic type parameter `<Post>` from the `InfiniteScroll` component in the `PostList` function example.
* Removed the `limit` prop from the `InfiniteScroll` component in the `PostList` function example.
* Removed the generic type parameter `<Message>` and the `limit` prop from the `InfiniteScroll` component in the reverse mode example.